### PR TITLE
Add .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,19 @@
+# To properly ignore non-Windows executables, we need to use negation patterns within .gitignore
+# This is because we aren't able to ignore a specific extension on an extensionless file
+# More info: https://stackoverflow.com/a/19023985
+
+# Ignore everything by default
+*
+
+# Don't ignore directories
+!/**/
+
+# Ignore the "out" directory specifically
+/out
+
+# Don't ignore markdown and .c files
+!*.md
+!*.c
+
+# Don't ignore this file
+!.gitignore


### PR DESCRIPTION
Added a `.gitignore` file to help make contributing to the repository a little easier. Now any resulting binaries or working directories cannot accidentally be committed to the repository. 

Due to non-Windows executables not having an extension, I had to get creative with negation patterns in the `.gitignore`. I put some comments in there to explain what I was doing in the event that files need whitelisted in the future.

Normally whitelisting for a `.gitignore` isn't the way to go, but it seems to be the only way to reliably ignore extensionless files :/